### PR TITLE
ci: publish healthcheckbot image

### DIFF
--- a/.github/workflows/deploy-bot.yml
+++ b/.github/workflows/deploy-bot.yml
@@ -1,6 +1,7 @@
 name: Build and Push Image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/deploy-bot.yml
+++ b/.github/workflows/deploy-bot.yml
@@ -1,37 +1,60 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
-name: Deployment
+name: Build and Push Image
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+    tags:
+      - "v*"
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
 
 jobs:
-  build:
+  build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup SSH
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.SSH_PRIVATE_KEY_GITHUB_ACTIONS }}
-          name: github-actions
-          known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+      - uses: actions/checkout@v4
 
-      - name: Deploy with rsync
-        run: rsync -avz --delete --exclude '.git/' --exclude 'docker-compose.yml' -e "ssh -i ~/.ssh/github-actions" . ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${{ secrets.DEPLOY_PATH }} --exclude=/.env
-
-      - name: executing remote ssh commands using ssh key
-        uses: appleboy/ssh-action@master
+      - uses: actions/setup-python@v5
         with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY_GITHUB_ACTIONS }}
-          port: ${{ secrets.SSH_PORT }}
-          script: |
-            cd ${{ secrets.DEPLOY_PATH }}
-            docker compose build
-            docker compose down
-            docker compose run --rm healthcheckbot aerich upgrade
-            docker compose up -d
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".[dev]"
+
+      - name: Lint and test
+        run: |
+          ruff check src/
+          ruff format src/ --check
+          PYTHONPATH=src python -m pytest tests/ -v --tb=short
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: registry.juanmadiaz.com
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - uses: docker/metadata-action@v5
+        id: metadata
+        with:
+          images: registry.juanmadiaz.com/apps/healthcheckbot
+          tags: |
+            type=sha,format=long
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=tag
+            type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}

--- a/tests/infrastructure/test_repositories_tortoise.py
+++ b/tests/infrastructure/test_repositories_tortoise.py
@@ -1,7 +1,8 @@
 from datetime import date, datetime, timezone
 
 import pytest
-from tortoise import Tortoise
+import pytest_asyncio
+from tortoise.contrib.test import tortoise_test_context
 
 from healthchecker.domain.models.url import Url
 from healthchecker.domain.models.health_check import HealthCheck
@@ -20,20 +21,12 @@ from healthchecker.infrastructure.persistence.daily_summary_repository import (
     TortoiseDailySummaryRepository,
 )
 
-
-@pytest.fixture(scope="module", autouse=True)
+@pytest_asyncio.fixture(autouse=True)
 async def init_tortoise():
-    await Tortoise.init(
-        db_url="sqlite://:memory:",
-        modules={
-            "models": [
-                "healthchecker.infrastructure.persistence.tortoise_models",
-            ]
-        },
-    )
-    await Tortoise.generate_schemas()
-    yield
-    await Tortoise.close_connections()
+    async with tortoise_test_context(
+        ["healthchecker.infrastructure.persistence.tortoise_models"]
+    ):
+        yield
 
 
 @pytest.fixture
@@ -63,7 +56,6 @@ async def sample_url(url_repo):
     )
 
 
-@pytest.mark.asyncio
 class TestTortoiseUrlRepository:
     async def test_add_and_get_by_id(self, url_repo):
         url = await url_repo.add(Url.create("https://test.com", name="Test"))
@@ -85,7 +77,6 @@ class TestTortoiseUrlRepository:
         assert await url_repo.get_by_id(url.id) is None
 
 
-@pytest.mark.asyncio
 class TestTortoiseHealthCheckRepository:
     async def test_save_and_get_latest(self, hc_repo, sample_url):
         now = datetime.now(timezone.utc)
@@ -166,7 +157,6 @@ class TestTortoiseHealthCheckRepository:
         assert len(filtered) >= 1
 
 
-@pytest.mark.asyncio
 class TestTortoiseAlertRepository:
     async def test_save_and_get_unsent(self, alert_repo, sample_url):
         now = datetime.now(timezone.utc)
@@ -200,7 +190,6 @@ class TestTortoiseAlertRepository:
         assert all(a.id != saved.id for a in unsent)
 
 
-@pytest.mark.asyncio
 class TestTortoiseDailySummaryRepository:
     async def test_save_and_get(self, summary_repo, sample_url):
         s = DailySummary(


### PR DESCRIPTION
## Summary
- Replace the SSH/Compose deployment workflow with test, build, and registry push steps.
- Publish an immutable commit-SHA tag; publish `latest` only for `main`.
- Use Tortoise's isolated test context so repository tests work with current pytest-asyncio loop handling.

## Validation
- `ruff check src/`
- `ruff format src/ --check`
- `PYTHONPATH=src python -m pytest tests/ -v --tb=short` (86 passed)
- `docker build --tag healthcheckbot:verify .`

The repository secrets `REGISTRY_USERNAME` and `REGISTRY_PASSWORD` are configured.