### PR TITLE
fix: make healthcheckbot image compatible with Kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ FROM python:3.14-slim
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
+RUN groupadd --gid 1000 healthcheckbot \
+    && useradd --uid 1000 --gid healthcheckbot --no-create-home \
+        --shell /usr/sbin/nologin healthcheckbot
+
 WORKDIR /app
 
 ENV VIRTUAL_ENV=/opt/venv
@@ -27,5 +31,7 @@ COPY ./src/ /app
 COPY pyproject.toml /app/pyproject.toml
 
 ENV PYTHONPATH=/app
+
+USER healthcheckbot
 
 CMD ["python", "-m", "healthchecker.main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
 
 COPY ./src/ /app
+COPY pyproject.toml /app/pyproject.toml
 
 ENV PYTHONPATH=/app
 


### PR DESCRIPTION
## Summary
- Include the real `pyproject.toml` so Aerich can load its configuration in the runtime image.
- Declare the UID 1000 runtime user required by the hardened Kubernetes security context.

## Validation
- Built the image locally.
- Confirmed `getpass.getuser()` resolves under UID 1000.
- Published image `sha-90142a75837c77cf7bd0be3c4d1ddc1a2b7f8839` successfully ran Aerich and the bot on K3s.