### PR TITLE
ci: notify GitOps on image release

### DIFF
--- a/.github/scripts/test-gitops-release-notification.sh
+++ b/.github/scripts/test-gitops-release-notification.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+workflow_file=".github/workflows/deploy-bot.yml"
+
+grep -Fqx "  notify-infra:" "$workflow_file"
+grep -Fq "needs: build-and-push" "$workflow_file"
+grep -Fq "github.event_name == 'push'" "$workflow_file"
+grep -Fq "github.ref_type == 'tag'" "$workflow_file"
+grep -Fq "actions/create-github-app-token@v2" "$workflow_file"
+grep -Fq "createDispatchEvent" "$workflow_file"
+grep -Fq "K8S_INFRA_APP_ID" "$workflow_file"
+grep -Fq "K8S_INFRA_APP_PRIVATE_KEY" "$workflow_file"
+
+echo "GitOps release notification contract passed"

--- a/.github/workflows/deploy-bot.yml
+++ b/.github/workflows/deploy-bot.yml
@@ -59,3 +59,30 @@ jobs:
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
+
+  notify-infra:
+    needs: build-and-push
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - id: infra-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.K8S_INFRA_APP_ID }}
+          private-key: ${{ secrets.K8S_INFRA_APP_PRIVATE_KEY }}
+          owner: torgus
+          repositories: k8s-infra
+
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.infra-token.outputs.token }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: "torgus",
+              repo: "k8s-infra",
+              event_type: "image-published",
+              client_payload: {
+                app: "healthcheckbot",
+                tag: context.ref.replace("refs/tags/", ""),
+              },
+            });


### PR DESCRIPTION
## Summary
- dispatches the immutable tag to k8s-infra only after a successful tag build
- uses a GitHub App installation token scoped to the infrastructure repository

## Validation
- release notification contract test
- actionlint