### PR TITLE
fix: retry transient health check failures

### DIFF
--- a/src/healthchecker/infrastructure/checker/http_checker.py
+++ b/src/healthchecker/infrastructure/checker/http_checker.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from dataclasses import dataclass
 
@@ -14,23 +15,41 @@ class HttpCheckResult:
 
 
 class HttpHealthChecker:
-    def __init__(self, timeout: float = 10.0):
+    def __init__(
+        self,
+        timeout: float = 10.0,
+        retry_attempts: int = 2,
+        retry_delay: float = 0.5,
+    ):
         self._timeout = timeout
+        self._retry_attempts = retry_attempts
+        self._retry_delay = retry_delay
 
     async def check(self, url: str) -> HttpCheckResult:
-        try:
-            async with httpx.AsyncClient(timeout=self._timeout) as client:
-                response = await client.get(url, follow_redirects=True)
-                ttfb = response.elapsed.total_seconds() * 1000
-                return HttpCheckResult(
-                    status_code=response.status_code, ttfb_ms=ttfb, error=None
-                )
-        except httpx.TimeoutException:
-            logger.warning("Timeout checking %s", url)
-            return HttpCheckResult(status_code=None, ttfb_ms=None, error="Timeout")
-        except httpx.RequestError as e:
-            logger.warning("Request error checking %s: %s", url, e)
-            return HttpCheckResult(status_code=None, ttfb_ms=None, error=str(e))
-        except Exception as e:
-            logger.exception("Unexpected error checking %s", url)
-            return HttpCheckResult(status_code=None, ttfb_ms=None, error=str(e))
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            for attempt in range(self._retry_attempts + 1):
+                try:
+                    response = await client.get(url, follow_redirects=True)
+                    ttfb = response.elapsed.total_seconds() * 1000
+                    return HttpCheckResult(
+                        status_code=response.status_code, ttfb_ms=ttfb, error=None
+                    )
+                except httpx.TimeoutException:
+                    error = "Timeout"
+                    logger.warning("Timeout checking %s", url)
+                except httpx.TransportError as e:
+                    error = str(e)
+                    logger.warning("Transport error checking %s: %s", url, e)
+                except httpx.RequestError as e:
+                    logger.warning("Request error checking %s: %s", url, e)
+                    return HttpCheckResult(status_code=None, ttfb_ms=None, error=str(e))
+                except Exception as e:
+                    logger.exception("Unexpected error checking %s", url)
+                    return HttpCheckResult(status_code=None, ttfb_ms=None, error=str(e))
+
+                if attempt == self._retry_attempts:
+                    return HttpCheckResult(status_code=None, ttfb_ms=None, error=error)
+
+                await asyncio.sleep(self._retry_delay)
+
+        raise RuntimeError("HTTP health check completed without a result")

--- a/tests/infrastructure/test_http_checker.py
+++ b/tests/infrastructure/test_http_checker.py
@@ -49,6 +49,22 @@ class TestHttpHealthChecker:
         assert result.ttfb_ms is None
         assert result.error == "DNS failure"
 
+    async def test_retries_transient_connection_error_before_returning_success(
+        self, checker, respx_mock
+    ):
+        route = respx_mock.get("https://example.com").mock(
+            side_effect=[
+                httpx.ConnectError("DNS failure"),
+                httpx.Response(200, content="ok"),
+            ]
+        )
+
+        result = await checker.check("https://example.com")
+
+        assert result.status_code == 200
+        assert result.error is None
+        assert route.call_count == 2
+
     async def test_unexpected_error(self, checker, respx_mock):
         respx_mock.get("https://example.com").mock(side_effect=RuntimeError("weird"))
         result = await checker.check("https://example.com")


### PR DESCRIPTION
## Change

Retries transient transport failures twice before reporting a monitored URL as down.

## Why

A short DNS or network interruption in the single-node cluster produced an immediate DOWN alert followed by UP on the next 60-second check.

## Verification

- Added a regression test for a DNS connection error followed by HTTP 200.
- `pytest tests/ -q` (91 passed).
- `ruff check src/ tests/` and `ruff format --check src/ tests/`.
